### PR TITLE
Add two flags to an example to clarify usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Example
 ```bash
 $ denomon --dir fixtures --allow net express.ts
 or
-$ denomon --allow net fixtures/express.ts
+$ denomon --allow net --allow read fixtures/express.ts
 or
 $ denomon fixtures/mod.ts
 ```


### PR DESCRIPTION
Hey :smile: 

First of all, thanks to the library!! Really cool job 

I took a minute to realize that we have to repeat the ```--allow``` flag in order to add more security action permissions. 
Maybe adding an example with two flags can help to clarify the usage of these flags. 

Using commas to separate the permissions would be very great too
For instance: 
``` denomon --dir src --allow env,read,net index.ts ``` 